### PR TITLE
Update pom.xml to version 3.3.8-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <!-- Warning!!! This WebJar does not use a git tag in the upstream repo. -->
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jstree.version>3.3.7</jstree.version>
+        <jstree.version>3.3.8</jstree.version>
         <downloadUrl>https://github.com/vakata/jstree/archive</downloadUrl>
         <!-- Note that this version doesn't match the upstream -->
         <destinationDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${jstree.version}</destinationDir>


### PR DESCRIPTION
Google chrome will deprecate the event registerElement 
used in version 3.3.7 for this reason there is an urgent 
need to update the project